### PR TITLE
Replace isarray and isobject with built-in js methods

### DIFF
--- a/lib/line-column.js
+++ b/lib/line-column.js
@@ -5,10 +5,6 @@
  */
 "use strict";
 
-var isArray  = require("isarray");
-var isObject = require("isobject");
-var slice = Array.prototype.slice;
-
 module.exports = LineColumnFinder;
 
 /**
@@ -72,10 +68,10 @@ LineColumnFinder.prototype.fromIndex = function (index) {
  */
 LineColumnFinder.prototype.toIndex = function (line, column) {
   if (typeof column === "undefined") {
-    if (isArray(line) && line.length >= 2) {
+    if (Array.isArray(line) && line.length >= 2) {
       return this.toIndex(line[0], line[1]);
     }
-    if (isObject(line) && "line" in line && ("col" in line || "column" in line)) {
+    if (line != null && typeof line === 'object' && "line" in line && ("col" in line || "column" in line)) {
       return this.toIndex(line.line, ("col" in line ? line.col : line.column));
     }
     return -1;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "mocha": "^2.4.5",
     "power-assert": "^1.3.1"
   },
-  "dependencies": {
-    "isarray": "^1.0.0",
-    "isobject": "^2.0.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
`isarray` and `isobject` are no longer required in the current state of JavaScript as there are native alternatives. Removing those dependencies can help to reduce unnecessary network traffic when this package is being installed.

Implemented testing and benchmark to make sure that the change doesn't break anything and the performance difference is within margin of error.

**Before**
```
long text  + line-column (not cached) x 117,262 ops/sec ±0.34% (87 runs sampled)
long text  + line-column (cached) x 12,636,686 ops/sec ±1.41% (90 runs sampled)
long text  + find-line-column x 59,024 ops/sec ±0.16% (99 runs sampled)
short text + line-column (not cached) x 3,438,077 ops/sec ±0.17% (97 runs sampled)
short text + line-column (cached) x 24,706,656 ops/sec ±1.50% (93 runs sampled)
short text + find-line-column x 1,638,901 ops/sec ±0.09% (98 runs sampled)
```
**After**
```
long text  + line-column (not cached) x 113,826 ops/sec ±2.28% (90 runs sampled)
long text  + line-column (cached) x 12,805,129 ops/sec ±0.45% (96 runs sampled)
long text  + find-line-column x 58,999 ops/sec ±0.18% (97 runs sampled)
short text + line-column (not cached) x 3,432,124 ops/sec ±0.18% (97 runs sampled)
short text + line-column (cached) x 24,947,691 ops/sec ±0.99% (89 runs sampled)
short text + find-line-column x 1,635,250 ops/sec ±0.13% (98 runs sampled)
```